### PR TITLE
introduce explicit mint and burn events for aex-141

### DIFF
--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -356,35 +356,21 @@ Issues a new token to the provided address. If the `owner` is a contract, NFTRec
 
 Emits the `Mint` event.
 
-Throws if
-- the call to NFTReceiver implementation failed (safe transfer)
-- the `mint_cap` would exceed
+Throws if the call to NFTReceiver implementation failed (safe transfer)
 
 ```sophia
 stateful entrypoint mint(owner: address, metadata: option(metadata), data: option(string)) : int
 ```
 
-| parameter | type | 
-| :--- | :--- | 
+| parameter | type |
+| :--- | :--- |
 | owner | address |
 | metadata | option(metadata) |
-| data  | option(string) | 
+| data  | option(string) |
 
 | return | type |
 | :--- | :--- |
 | token_id | int |
-
-### mint_cap\(\)
-
-Returns the defined `mint_cap` which indicates the maximum supply of NFTs the contract can potentially have. If unlimited minting is allowed, `None` MUST be returned.
-
-```sophia
-stateful entrypoint mint_cap() : option(int)
-```
-
-| return | type |
-| :--- | :--- |
-| mint_cap | option(int) |
 
 ## Extension Burnable ("burnable")
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -338,7 +338,7 @@ The standard only allows safe transfers of tokens. On transfer a check MUST be p
 
 ```sophia
 contract interface NFTReceiver = 
-    entrypoint on_nft_received : (option(string)) => bool
+    entrypoint on_nft_received : (int, option(string)) => bool
 ```
 
 ### on_nft_received\(\)
@@ -348,10 +348,11 @@ Deals with receiving NFTs on behalf of a contract. Contracts MUST implement this
 Returns `true` or `false` to signal whether processing the received NFT was successful or not.
 
 ```sophia
-entrypoint on_nft_received(data: option(string)) : bool
+entrypoint on_nft_received(token_id: int, data: option(string)) : bool
 ```
 | parameter | type |
 | :--- | :--- |
+| token_id | int |
 | data | option(string) |
 
 # Extensions

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -3,7 +3,7 @@
 ```
 AEX: 141
 Title: Non-Fungible Token Standard
-Author: Arjan van Eersel <arjan@toqns.com> (@zkvonsnarkenstein)
+Author: Arjan van Eersel <arjan@toqns.com> (@zkvonsnarkenstein), Marco Walz (@marc0olo), Philipp (@thepiwo)
 License: ISC
 Discussions-To: https://forum.aeternity.com/t/aeternity-nft-token-standard/9781
 Status: Review
@@ -37,7 +37,8 @@ contract interface NFT =
         , metadata_type : metadata_type}
 
     datatype event 
-        = Transfer(address, address, int)
+        = Mint(address, int)
+        | Transfer(address, address, int)
         | Approval(address, address, int, string)
         | ApprovalForAll(address, address, string)
 
@@ -243,14 +244,31 @@ entrypoint is_approved_for_all(owner: address, operator: address) : bool
 
 ```sophia
 datatype event 
-        = Transfer(address, address, int)
+        = Mint(address, int)
+        | Transfer(address, address, int)
         | Approval(address, address, int, string)
         | ApprovalForAll(address, address, string)
 ```
 
+### *Mint*
+
+This event MUST be triggered whenever a new token is minted.
+
+The event arguments should be as follows: `(to, token_id)`
+
+```sophia
+Mint(address, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| to | address |
+| token_id | int |
+
+
 ### *Transfer*
 
-This event MUST be triggered and emitted when tokens are transferred, including zero value transfers.
+This event MUST be triggered and emitted when tokens are transferred.
 
 The event arguments should be as follows: `(from, to, token_id)`
 
@@ -305,7 +323,9 @@ ApprovalForAll(address, address, string)
 ### mint\(\)
 
 Issues a new token to the provided address. If the `owner` is a contract, NFTReceiver will be called with `data` if provided.
-Emits a Transfer event.
+
+Emits the `Mint` event.
+
 Throws if the call to NFTReceiver implementation failed (safe transfer). 
 
 ```sophia
@@ -327,7 +347,8 @@ stateful entrypoint mint(owner: address, metadata: option(metadata), data: optio
 ### burn\(\)
 
 Burns the NFT with the provided `token_id`.
-Emits the `Transfer` event.
+
+Emits the `Burn` event.
 
 ```sophia
 stateful entrypoint burn(token_id: int) : unit
@@ -349,10 +370,6 @@ stateful entrypoint swap() : unit
 
 | parameter | type |
 | :--- | :--- |
-
-| return | type |
-| :--- | :--- |
-| () | unit |
 
 ### check_swap\(\)
 
@@ -384,9 +401,22 @@ stateful entrypoint swapped() : map(address, int)
 
 ## Events
 
+**Burn** - MUST trigger when tokens are burned using the `burn` function.
+
+The burn event arguments should be as follows: `(from, token_id)`
+
+```sophia
+Burn(address, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| from | address |
+| token_id | int |
+
 **Swap** - MUST trigger when tokens are swapped using the `swap` function.
 
-The swap event arguments should be as follows: `(account,  value)`
+The swap event arguments should be as follows: `(from,  token_id)`
 
 ```sophia
 Swap(address, int)
@@ -394,8 +424,8 @@ Swap(address, int)
 
 | parameter | type |
 | :--- | :--- |
-| account| address |
-| value | int |
+| from | address |
+| token_id | int |
 
 # Receiver contract interface
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -356,7 +356,9 @@ Issues a new token to the provided address. If the `owner` is a contract, NFTRec
 
 Emits the `Mint` event.
 
-Throws if the call to NFTReceiver implementation failed (safe transfer). 
+Throws if
+- the call to NFTReceiver implementation failed (safe transfer)
+- the `mint_cap` would exceed
 
 ```sophia
 stateful entrypoint mint(owner: address, metadata: option(metadata), data: option(string)) : int

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -324,7 +324,7 @@ The standard only allows safe transfers of tokens. On transfer a check MUST be p
 
 ```sophia
 contract interface NFTReceiver = 
-    entrypoint on_nft_received : (address, address, int, option(string)) => bool
+    entrypoint on_nft_received : (option(string)) => bool
 ```
 
 ### on_nft_received\(\)
@@ -334,13 +334,10 @@ Deals with receiving NFTs on behalf of a contract. Contracts MUST implement this
 Returns `true` or `false` to signal whether processing the received NFT was successful or not.
 
 ```sophia
-entrypoint on_nft_received(from: address, to: address, token_id: int, data: option(string)) : bool
+entrypoint on_nft_received(data: option(string)) : bool
 ```
 | parameter | type |
 | :--- | :--- |
-| from | address |
-| to | address |
-| token_id | int |
 | data | option(string) |
 
 # Extensions

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -413,9 +413,6 @@ Burns all NFTs of `Call.caller` and stores the NFT ids in the swapped map.
 stateful entrypoint swap() : unit
 ```
 
-| parameter | type |
-| :--- | :--- |
-
 ### check_swap\(\)
 
 Returns the amount of NFTs that were burned through `swap` for the provided account.
@@ -434,15 +431,15 @@ stateful entrypoint check_swap(account: address) : int
 
 ### swapped\(\)
 
-Returns all of the swapped NFTs that are stored in contract state.
+Returns the map with the swapped NFTs per address.
 
 ```sophia
-stateful entrypoint swapped() : map(address, int)
+stateful entrypoint swapped() : map(address, Set.set(int))
 ```
 
 | return | type |
 | :--- | :--- |
-| swapped | map(address, int) |
+| swapped | map(address, Set.set(int)) |
 
 ## Events
 
@@ -459,7 +456,7 @@ Burn(address, int)
 | owner | address |
 | token_id | int |
 
-**Swap** - MUST trigger when NFTs are swapped using the `swap` function.
+**Swap** - MUST trigger for each NFT that is swapped using the `swap` function.
 
 The swap event arguments should be as follows: `(owner,  token_id)`
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -13,11 +13,13 @@ Created: 2021-09-11
 
 ## Abstract
 
-A standard implementation of non-fungible tokens for the æternity ecosystem. The design goal of the primary interface is to be as compatible with ERC-721 as possible, so that anyone who can work with ERC-721 can work with this interface. However, where Sophia offers a better way, performance and efficiency should prevail over compatibility.
+A standard implementation of non-fungible tokens for the æternity ecosystem. Initially, the design goal of the primary interface was to be as compatible with ERC-721 as possible, so that anyone who can work with ERC-721 can work with this interface. However, specifically when it comes to dealing with metadata a decision was taken to provide contract developers as much flexibility as possible.
 
-There is no support for unsafe transactions. Therefore, all transactions are ought to be safe.
-
-For minting it is expected that different options will evolve over time. The way minting is done has to be defined via extensions.
+Core differences to the well-known ERC-721 standard:
+- Unsafe transactions are not supported. Therefore, all transactions are ought to be safe
+- Usage of zero-address for minting or burning is avoided. Thus, explicit events for minting and burning have been defined
+- Token transfers do not require the (owner) address to be passed. Only the recipient address needs to be provided to the entrypoint
+- High flexibility when it comes to dealing with metadata is provided
 
 ## Motivation
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -15,7 +15,7 @@ Created: 2021-09-11
 
 A standard implementation of non-fungible tokens for the æternity ecosystem. The design goal of the primary interface is to be as compatible with ERC-721 as possible, so that anyone who can work with ERC-721 can work with this interface. However, where Sophia offers a better way, performance and efficiency should prevail over compatibility.
 
-There is no support for unsafe transactions. Therefore all transactions are ought to be safe.
+There is no support for unsafe transactions. Therefore, all transactions are ought to be safe.
 
 For minting it is expected that different options will evolve over time. The way minting is done has to be defined via extensions.
 
@@ -36,7 +36,7 @@ contract interface IAEX141 =
         { name: string
         , symbol: string 
         , base_url: option(string)
-        , metadata_type : metadata_type}
+        , metadata_type : metadata_type }
 
     datatype event 
         = Transfer(address, address, int)
@@ -92,9 +92,11 @@ entrypoint meta_info() : meta_info
 
 ### metadata\(\)
 
-Returns metadata associated with an NFT. 
-The function is a part of the basic interface, because metadata can be set in the constructor, 
-as well as by implementing the Mintable extention.
+Returns metadata associated with an NFT.
+
+Note:
+- The `metadata` can be set in the constructor, as well as by implementing the extensions like e.g. `mintable`
+- The `metadata` type MUST be defined on contract level and MUST NOT be mixed across various NFTs in a contract
 
 ```sophia
 entrypoint metadata(token_id: int) : option(metadata)
@@ -108,9 +110,15 @@ entrypoint metadata(token_id: int) : option(metadata)
 | :--- | :--- |
 | data | option(metadata) |
 
-The `metadata` type to use depends on the `metadata_type` defined in the contract:
+The `metadata` to use depends on the `metadata_type` defined in the contract and provides a lot of flexibility:
 - for `URL` and `OBJECT_ID` use `MetadataIdentifier`
+    - `URL` can represent any URL and typically the NFT id is used to resolve the metadata using that URL, e.g.
+        - `ipfs://` for pointing to a folder stored on IPFS where immutable metadata is stored (recommended)
+        - `https://` for pointing to a traditional website where metadata can be accessed
+        - ...
+    - `OBJECT_ID` can be used to refer to any kind of item which typically already exists (e.g. the VIN of a car)
 - for `MAP` use `MetadataMap`
+    - `MAP` provides almost unlimited flexibility and allows any kind of metadata to be represented in a map
 
 ### total_supply\(\)
 
@@ -238,7 +246,7 @@ entrypoint is_approved(token_id: int, approved: address) : bool
 
 Returns `true` if `operator` is approved to commit transactions on behalf of `owner`.
 
-Indicates wether an address is an authorized operator for another address.
+Indicates whether an address is an authorized operator for another address.
 
 ```sophia
 entrypoint is_approved_for_all(owner: address, operator: address) : bool

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -446,7 +446,7 @@ entrypoint token_limit() : ínt
 
 ### change_token_limit\(\)
 
-Changes the the NFT limit/cap defined in the collection. The limit/cap MAY ONLY be decreased.
+Changes the NFT limit/cap defined in the collection. The limit/cap MAY ONLY be decreased.
 
 Emits the `TokenLimitChange` event.
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -84,6 +84,10 @@ entrypoint aex141_extensions() : list(string)
 
 Returns meta information associated with the contract.
 
+Note:
+- The `base_url` is optional and is only intended to be used if the `metadata_type` is `URL`. As known from ERC-721 this can be used to resolve metadata for a specific NFT which can be fetched from an URL based on the token id
+- The `metadata_type` MUST be defined on contract level and MUST NOT be mixed across various NFTs in a contract
+
 ```sophia
 entrypoint meta_info() : meta_info
 ```
@@ -97,8 +101,16 @@ entrypoint meta_info() : meta_info
 Returns metadata associated with an NFT.
 
 Note:
-- The `metadata` can be set in the constructor, as well as by implementing the extensions like e.g. `mintable`
-- The `metadata` type MUST be defined on contract level and MUST NOT be mixed across various NFTs in a contract
+- The `metadata` can be set in the constructor, as well as by implementing extensions like e.g. `mintable`
+- The `metadata` to use depends on the `metadata_type` defined on contract level and provides certain flexibility:
+  - for `URL` and `OBJECT_ID` use `MetadataIdentifier`
+      - `URL` can represent any URL and typically the NFT id is used to resolve the metadata using that URL, e.g.
+          - `ipfs://` serving as `base_url` and pointing to a folder stored on IPFS where immutable metadata is stored (recommended)
+          - `https://` serving as `base_url` and pointing to a traditional website where metadata is stored
+          - ...
+      - `OBJECT_ID` can be used to refer to any kind of item which typically already exists (e.g. the VIN of a car)
+  - for `MAP` use `MetadataMap`
+    - `MAP` provides almost unlimited flexibility and allows any kind of metadata to be represented in a map
 
 ```sophia
 entrypoint metadata(token_id: int) : option(metadata)
@@ -111,16 +123,6 @@ entrypoint metadata(token_id: int) : option(metadata)
 | return | type |
 | :--- | :--- |
 | data | option(metadata) |
-
-The `metadata` to use depends on the `metadata_type` defined in the contract and provides a lot of flexibility:
-- for `URL` and `OBJECT_ID` use `MetadataIdentifier`
-    - `URL` can represent any URL and typically the NFT id is used to resolve the metadata using that URL, e.g.
-        - `ipfs://` for pointing to a folder stored on IPFS where immutable metadata is stored (recommended)
-        - `https://` for pointing to a traditional website where metadata can be accessed
-        - ...
-    - `OBJECT_ID` can be used to refer to any kind of item which typically already exists (e.g. the VIN of a car)
-- for `MAP` use `MetadataMap`
-    - `MAP` provides almost unlimited flexibility and allows any kind of metadata to be represented in a map
 
 ### total_supply\(\)
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -50,6 +50,8 @@ contract interface NFT =
 
     entrypoint balance : (address) => option(int)
 
+    entrypoint total_supply : () => int
+
     entrypoint owner : (int) => option(address)
    
     stateful entrypoint transfer : (address, int, option(string)) => unit
@@ -108,6 +110,18 @@ entrypoint metadata(token_id: int) : option(metadata)
 The `metadata` type to use depends on the `metadata_type` defined in the contract:
 - for `URL`, `IPFS` and `OBJECT_ID` use `MetadataIdentifier`
 - for `MAP` use `MetadataMap`
+
+### total_supply\(\)
+
+Returns the total amount of NFTs in circulation.
+
+```sophia
+entrypoint total_supply() : ínt
+```
+
+| return | type |
+| :--- | :--- |
+| total_supply | int |
 
 ### balance\(\)
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -17,6 +17,8 @@ A standard implementation of non-fungible tokens for the Aeternity ecosystem. Th
 
 There is no support for unsafe transactions. Therefore all transactions are ought to be safe.
 
+For minting it is expected that different options will evolve over time. The way minting is done has to be defined via extensions.
+
 ## Motivation
 
 The following standard describes standard interfaces for non-fungible tokens. The proposal contains a primary interface and secondary interfaces for optional functionality that not everyone might need. 
@@ -367,6 +369,18 @@ stateful entrypoint mint(owner: address, metadata: option(metadata), data: optio
 | return | type |
 | :--- | :--- |
 | token_id | int |
+
+### mint_cap\(\)
+
+Returns the defined `mint_cap` which indicates the maximum supply the collection can potentially have. If unlimited minting is allowed, `None` MUST be returned.
+
+```sophia
+stateful entrypoint mint_cap() : option(int)
+```
+
+| return | type |
+| :--- | :--- |
+| mint_cap | option(int) |
 
 ## Extension Burnable ("burnable")
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -358,7 +358,7 @@ entrypoint on_nft_received(data: option(string)) : bool
 
 This section covers the extendability of the basic token - e.g. mintable, burnable.
 
-When a token contract implements an extension its name should be included in the `aex141_extensions` array, in order for third party software or contracts to know the interface.
+When an NFT contract implements an extension its name should be included in the `aex141_extensions` array, in order for third party software or contracts to know the interface.
 Any extensions should be implementable without permission. Developers of extensions MUST choose a name for `aex141_extensions` that is not yet used. Developers CAN make a pull request to the reference implementation for general purpose extensions and maintainers choose to eventually include them.
 
 ## Extension Mintable ("mintable")
@@ -407,7 +407,7 @@ stateful entrypoint burn(token_id: int) : unit
 
 ### swap\(\)
 
-Burns the whole balance of `Call.caller` and stores the same amount in the `swapped` map. 
+Burns all NFTs of `Call.caller` and stores the NFT ids in the swapped map.
 
 ```sophia
 stateful entrypoint swap() : unit
@@ -418,7 +418,7 @@ stateful entrypoint swap() : unit
 
 ### check_swap\(\)
 
-Returns the amount of NFTs that were burned through `swap` for the provided account. 
+Returns the amount of NFTs that were burned through `swap` for the provided account.
 
 ```sophia
 stateful entrypoint check_swap(account: address) : int
@@ -434,7 +434,7 @@ stateful entrypoint check_swap(account: address) : int
 
 ### swapped\(\)
 
-Returns all of the swapped NFTs that are stored in contract state. 
+Returns all of the swapped NFTs that are stored in contract state.
 
 ```sophia
 stateful entrypoint swapped() : map(address, int)

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -37,8 +37,7 @@ contract interface NFT =
         , metadata_type : metadata_type}
 
     datatype event 
-        = Mint(address, int)
-        | Transfer(address, address, int)
+        = Transfer(address, address, int)
         | Approval(address, address, int, string)
         | ApprovalForAll(address, address, string)
 
@@ -256,27 +255,10 @@ entrypoint is_approved_for_all(owner: address, operator: address) : bool
 
 ```sophia
 datatype event 
-        = Mint(address, int)
-        | Transfer(address, address, int)
+        = Transfer(address, address, int)
         | Approval(address, address, int, string)
         | ApprovalForAll(address, address, string)
 ```
-
-### *Mint*
-
-This event MUST be triggered whenever a new token is minted.
-
-The event arguments should be as follows: `(to, token_id)`
-
-```sophia
-Mint(address, int)
-```
-
-| parameter | type |
-| :--- | :--- |
-| to | address |
-| token_id | int |
-
 
 ### *Transfer*
 
@@ -442,7 +424,22 @@ stateful entrypoint swapped() : map(address, Set.set(int))
 | :--- | :--- |
 | swapped | map(address, Set.set(int)) |
 
-## Events
+## Extension Events
+
+**Mint**
+
+This event MUST be triggered whenever a new token is minted.
+
+The event arguments should be as follows: `(to, token_id)`
+
+```sophia
+Mint(address, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| to | address |
+| token_id | int |
 
 **Burn** - MUST trigger when NFTs are burned using the `burn` function.
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -51,13 +51,15 @@ contract interface IAEX141 =
 
     entrypoint metadata : (int) => option(metadata)
 
-    entrypoint balance : (address) => option(int)
-
     entrypoint total_supply : () => int
+
+    entrypoint balance : (address) => option(int)
 
     entrypoint owner : (int) => option(address)
    
     stateful entrypoint transfer : (address, int, option(string)) => unit
+
+    stateful entrypoint transfer_to_contract : (int) => unit
 
     stateful entrypoint approve : (address, int, bool) => unit
 
@@ -171,6 +173,8 @@ entrypoint owner(token_id: int) : option(address)
 ### transfer\(\)
 Transfers NFT with ID `token_id` from the current owner to the `to` address. Will invoke `IAEX141Receiver.on_aex141_received` if the `to` address belongs to a contract. If provided, `data` will be submitted with the invocation of `IAEX141Receiver.on_aex141_received`. Emits the `Transfer` event.
 
+Note: For security reasons reentrancy is not possible. Therefore contracts cannot use this entrypoint to transfer NFTs to itself. Use `transfer_to_contract` instead to cover this scenario.
+
 Throws if:
 - `Call.caller` is NOT the current owner or NOT approved to transfer on behalf of the owner;
 - `token_id` is NOT a valid token;
@@ -182,8 +186,24 @@ stateful entrypoint transfer(to: address, token_id: int, data: option(string)) :
 
 | parameter | type |
 | :--- | :--- |
+| token_id | int |
+| data | option(string) |
+
+### transfer_to_contract\(\)
+Transfers NFT with ID `token_id` from the current owner to the contract calling this entrypoint. As reentrancy is not possible for security reasons, this entrypoint MUST be used if a contract (e.g. NFT marketplace) wants to transfer the NFT to itself on behalf of the owner. Emits the `Transfer` event.
+
+Throws if:
+- `Call.caller` is NOT a contract or NOT approved to transfer on behalf of the owner;
+- `token_id` is NOT a valid token;
+
+```sophia
+stateful entrypoint transfer(to: address, token_id: int, data: option(string)) : unit
+```
+
+| parameter | type |
+| :--- | :--- |
 | to | address |
-| token | int |
+| token_id | int |
 | data | option(string) |
 
 ### approve\(\)

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -405,6 +405,44 @@ stateful entrypoint mint(owner: address, metadata: option(metadata), data: optio
 | :--- | :--- |
 | token_id | int |
 
+## Extension Mintable Limit ("mintable_limit")
+
+The `mintable_limit` extension SHOULD be used if the amount of NFTs to mint should be limited/capped. It MAY ONLY be used in combination with the `mintable` extension.
+
+The initially defined token limit MUST be greater than or equal to 1.
+
+Emits the `TokenLimit` event on contract creation.
+
+### token_limit\(\)
+
+Returns the limit / max amount of NFTs that can be minted.
+
+```sophia
+entrypoint token_limit() : ínt
+```
+
+| return | type |
+| :--- | :--- |
+| token_limit | int |
+
+### change_token_limit\(\)
+
+Changes the the NFT limit/cap defined in the collection. The limit/cap MAY ONLY be decreased.
+
+Emits the `TokenLimitChange` event.
+
+Throws if:
+- `new_limit` equals the current `token_limit`
+- `new_limit` is lower than the current `total_supply`
+
+```sophia
+stateful entrypoint change_token_limit(new_limit: int) : unit
+```
+
+| parameter | type |
+| :--- | :--- |
+| new_limit | int |
+
 ## Extension Burnable ("burnable")
 
 The `burnable` extension SHOULD be used if NFTs within a contract are intended to be burnable.
@@ -441,6 +479,35 @@ Mint(address, int)
 | :--- | :--- |
 | to | address |
 | token_id | int |
+
+**TokenLimit**
+
+This event MUST be triggered in the `init` entrypoint during contract creation if the contract implements the `mintable_limit` extension.
+
+The event arguments should be as follows: `(limit)`
+
+```sophia
+TokenLimit(int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| limit | int |
+
+**TokenLimitChange**
+
+This event MUST be triggered if the contract implements the `mintable_limit` extension and the `change_token_limit` entrypoint is called.
+
+The event arguments should be as follows: `(old_limit, new_limit)`
+
+```sophia
+TokenLimitChange(int, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| old_limit | int |
+| new_limit | int |
 
 **Burn**
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -410,15 +410,21 @@ The `swappable` extension SHOULD be used if it is expected to migrate the NFTs t
 
 ### swap\(\)
 
-Burns all NFTs of `Call.caller` and stores the NFT ids in the swapped map.
+Swaps (burns) a set of NFTs of `Call.caller` and stores the NFT ids in the swapped map. Depending on gas consumption a reasonable amount NFTs shall be swapped at once. If `amount_remaining > 0` the `swap` entrypoint needs to be called again in order to swap all NFTs.
+
+Emits the `Swap(address, int)` event for each swapped (burned) NFT.
 
 ```sophia
-stateful entrypoint swap() : unit
+stateful entrypoint swap() : (int, int)
 ```
+
+| return | type |
+| :--- | :--- |
+| (amount_swapped, amount_remaining) | (int, int) |
 
 ### check_swap\(\)
 
-Returns the amount of NFTs that were burned through `swap` for the provided account.
+Returns the amount of NFTs that were swapped (burned) through `swap` for the provided account.
 
 ```sophia
 stateful entrypoint check_swap(account: address) : int
@@ -430,7 +436,7 @@ stateful entrypoint check_swap(account: address) : int
 
 | return | type |
 | :--- | :--- |
-| int | int |
+| amount_swapped | int |
 
 ### swapped\(\)
 
@@ -448,7 +454,7 @@ stateful entrypoint swapped() : map(address, Set.set(int))
 
 **Mint**
 
-This event MUST be triggered whenever a new token is minted.
+This event MUST be triggered whenever a new token is minted with the `mintable` extension.
 
 The event arguments should be as follows: `(to, token_id)`
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -134,7 +134,7 @@ entrypoint total_supply() : ínt
 
 ### balance\(\)
 
-Returns the account balance of another account with address `owner` if the account has a balance. If the owner address is unknown to the contract, `None` will be returned. Using `option` type as a return value allows us to determine if the account has balance of 0, more than 0, or the account has never had balance and is still unknown to the contract.
+Returns the number of NFTs owned by the account with address `owner` in the contract. If the owner address is unknown to the contract, `None` will be returned. Using `option` type as a return value allows us to determine if the account owns 0, more than 0, or the account has never owned a balance and is still unknown to the contract.
 
 ```sophia
 entrypoint balance(owner: address) : option(int)

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -383,6 +383,14 @@ Any extensions should be implementable without permission. Developers of extensi
 
 The `mintable` extension SHOULD be used for generic NFT minting without specific requirements in regards to minting.
 
+```sophia
+contract interface IAEX141Mintable =
+
+    datatype event = Mint(address, int)
+
+    stateful entrypoint mint : (address, option(metadata), option(string)) => int
+```
+
 ### mint\(\)
 
 Issues a new token to the provided address. If the `owner` is a contract, `IAEX141Receiver.on_aex141_received` will be called with `data` if provided.
@@ -412,6 +420,17 @@ The `mintable_limit` extension SHOULD be used if the amount of NFTs to mint shou
 The initially defined token limit MUST be greater than or equal to 1.
 
 Emits the `TokenLimit` event on contract creation.
+
+```sophia
+contract interface IAEX141MintableLimit =
+
+    datatype event
+        = TokenLimit(int)
+        | TokenLimitChange(int, int)
+
+    entrypoint token_limit : () => int
+    stateful entrypoint change_token_limit : (int) => unit
+```
 
 ### token_limit\(\)
 
@@ -446,6 +465,14 @@ stateful entrypoint change_token_limit(new_limit: int) : unit
 ## Extension Burnable ("burnable")
 
 The `burnable` extension SHOULD be used if NFTs within a contract are intended to be burnable.
+
+```sophia
+contract interface IAEX141Burnable =
+
+    datatype event = Burn(address, int)
+
+    stateful entrypoint burn : (int) => unit
+```
 
 ### burn\(\)
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -108,7 +108,7 @@ entrypoint metadata(token_id: int) : option(metadata)
 | data | option(metadata) |
 
 The `metadata` type to use depends on the `metadata_type` defined in the contract:
-- for `URL`, and `OBJECT_ID` use `MetadataIdentifier`
+- for `URL` and `OBJECT_ID` use `MetadataIdentifier`
 - for `MAP` use `MetadataMap`
 
 ### total_supply\(\)
@@ -164,7 +164,7 @@ Throws if:
 - the invocation of `NFTReceiver` fails.
 
 ```sophia
-stateful entrypoint transfer(from: address, to: address, token_id: int, data: option(string)) : unit
+stateful entrypoint transfer(to: address, token_id: int, data: option(string)) : unit
 ```
 
 | parameter | type |

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -348,6 +348,8 @@ Any extensions should be implementable without permission. Developers of extensi
 
 ## Extension Mintable ("mintable")
 
+The `mintable` extension SHOULD be used for generic NFT minting without specific requirements in regards to minting.
+
 ### mint\(\)
 
 Issues a new token to the provided address. If the `owner` is a contract, NFTReceiver will be called with `data` if provided.
@@ -372,7 +374,7 @@ stateful entrypoint mint(owner: address, metadata: option(metadata), data: optio
 
 ### mint_cap\(\)
 
-Returns the defined `mint_cap` which indicates the maximum supply the collection can potentially have. If unlimited minting is allowed, `None` MUST be returned.
+Returns the defined `mint_cap` which indicates the maximum supply of NFTs the contract can potentially have. If unlimited minting is allowed, `None` MUST be returned.
 
 ```sophia
 stateful entrypoint mint_cap() : option(int)
@@ -383,6 +385,8 @@ stateful entrypoint mint_cap() : option(int)
 | mint_cap | option(int) |
 
 ## Extension Burnable ("burnable")
+
+The `burnable` extension SHOULD be used if NFTs within a contract are intended to be burnable.
 
 ### burn\(\)
 
@@ -401,6 +405,8 @@ stateful entrypoint burn(token_id: int) : unit
 | token_id | int |
 
 ## Extension Swappable ("swappable")
+
+The `swappable` extension SHOULD be used if it is expected to migrate the NFTs to a new contract or to another blockchain.
 
 ### swap\(\)
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -392,54 +392,6 @@ stateful entrypoint burn(token_id: int) : unit
 | :--- | :--- |
 | token_id | int |
 
-## Extension Swappable ("swappable")
-
-The `swappable` extension SHOULD be used if it is expected to migrate the NFTs to a new contract or to another blockchain.
-
-### swap\(\)
-
-Swaps (burns) a set of NFTs owned by `Call.caller` and stores the NFT ids in the swapped map. Depending on gas consumption only a reasonable amount NFTs can be swapped at once. The entrypoint might have to be called multiple times in order to complete a swap.
-
-Emits the `Swap(address, int)` event for each swapped (burned) NFT.
-
-Returns `true` if the swap is complete and all NFTs have been swapped (burned) OR `false` if there are still NFTs remaining which have to be swapped (burned) by calling `swap()` again.
-
-```sophia
-stateful entrypoint swap() : bool
-```
-
-| return | type |
-| :--- | :--- |
-| complete | bool |
-
-### check_swap\(\)
-
-Returns the list of NFTs that were swapped (burned) through `swap` for the provided account.
-
-```sophia
-stateful entrypoint check_swap(account: address) : list(int)
-```
-
-| parameter | type |
-| :--- | :--- |
-| account | address |
-
-| return | type |
-| :--- | :--- |
-| swapped_tokens | list(int) |
-
-### swapped\(\)
-
-Returns the map with the swapped NFTs per address.
-
-```sophia
-stateful entrypoint swapped() : map(address, Set.set(int))
-```
-
-| return | type |
-| :--- | :--- |
-| swapped_map | map(address, Set.set(int)) |
-
 ## Extension Events
 
 **Mint**
@@ -463,19 +415,6 @@ The burn event arguments should be as follows: `(owner, token_id)`
 
 ```sophia
 Burn(address, int)
-```
-
-| parameter | type |
-| :--- | :--- |
-| owner | address |
-| token_id | int |
-
-**Swap** - MUST trigger for each NFT that is swapped using the `swap` function.
-
-The swap event arguments should be as follows: `(owner,  token_id)`
-
-```sophia
-Swap(address, int)
 ```
 
 | parameter | type |

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -418,7 +418,7 @@ Mint(address, int)
 | to | address |
 | token_id | int |
 
-**Burn** - MUST trigger when NFTs are burned using the `burn` function.
+**Burn** - MUST trigger whenever and NFT is burned.
 
 The burn event arguments should be as follows: `(owner, token_id)`
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -410,17 +410,19 @@ The `swappable` extension SHOULD be used if it is expected to migrate the NFTs t
 
 ### swap\(\)
 
-Swaps (burns) a set of NFTs of `Call.caller` and stores the NFT ids in the swapped map. Depending on gas consumption a reasonable amount NFTs shall be swapped at once. If `amount_remaining > 0` the `swap` entrypoint needs to be called again in order to swap all NFTs.
+Swaps (burns) a set of NFTs owned by `Call.caller` and stores the NFT ids in the swapped map. Depending on gas consumption only a reasonable amount NFTs can be swapped at once. The entrypoint might have to be called multiple times in order to complete a swap.
 
 Emits the `Swap(address, int)` event for each swapped (burned) NFT.
 
+Returns `true` if the swap is complete and all NFTs have been swapped (burned) OR `false` if there are still NFTs remaining which have to be swapped (burned) by calling `swap()` again.
+
 ```sophia
-stateful entrypoint swap() : (int, int)
+stateful entrypoint swap() : bool
 ```
 
 | return | type |
 | :--- | :--- |
-| (amount_swapped, amount_remaining) | (int, int) |
+| complete | bool |
 
 ### check_swap\(\)
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -28,7 +28,7 @@ The following standard describes standard interfaces for non-fungible tokens. Th
 ## IAEX141
 
 ```sophia
-contract interface NFT =
+contract interface IAEX141 =
     datatype metadata_type = URL | OBJECT_ID | MAP
     datatype metadata = MetadataIdentifier(string) | MetadataMap(map(string, string))
 
@@ -157,12 +157,12 @@ entrypoint owner(token_id: int) : option(address)
 | owner | option(address) |
 
 ### transfer\(\)
-Transfers NFT with ID `token_id` from the current owner to the `to` address. Will invoke `NFTReceiver` if `to` address belongs to a contract. If provided, `data` will be submitted with the invocation of `NFTReceiver`. Emits the `Transfer` event.
+Transfers NFT with ID `token_id` from the current owner to the `to` address. Will invoke `IAEX141Receiver.on_aex141_received` if the `to` address belongs to a contract. If provided, `data` will be submitted with the invocation of `IAEX141Receiver.on_aex141_received`. Emits the `Transfer` event.
 
 Throws if:
 - `Call.caller` is NOT the current owner or NOT approved to transfer on behalf of the owner;
-- `token` is NOT a valid token;
-- the invocation of `NFTReceiver` fails.
+- `token_id` is NOT a valid token;
+- the invocation of `IAEX141Receiver.on_aex141_received` fails.
 
 ```sophia
 stateful entrypoint transfer(to: address, token_id: int, data: option(string)) : unit
@@ -353,11 +353,11 @@ The `mintable` extension SHOULD be used for generic NFT minting without specific
 
 ### mint\(\)
 
-Issues a new token to the provided address. If the `owner` is a contract, NFTReceiver will be called with `data` if provided.
+Issues a new token to the provided address. If the `owner` is a contract, `IAEX141Receiver.on_aex141_received` will be called with `data` if provided.
 
 Emits the `Mint` event.
 
-Throws if the call to NFTReceiver implementation failed (safe transfer)
+Throws if the call to `IAEX141Receiver.on_aex141_received` implementation failed (safe transfer)
 
 ```sophia
 stateful entrypoint mint(owner: address, metadata: option(metadata), data: option(string)) : int

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -414,10 +414,10 @@ stateful entrypoint swap() : bool
 
 ### check_swap\(\)
 
-Returns the amount of NFTs that were swapped (burned) through `swap` for the provided account.
+Returns the list of NFTs that were swapped (burned) through `swap` for the provided account.
 
 ```sophia
-stateful entrypoint check_swap(account: address) : int
+stateful entrypoint check_swap(account: address) : list(int)
 ```
 
 | parameter | type |
@@ -426,7 +426,7 @@ stateful entrypoint check_swap(account: address) : int
 
 | return | type |
 | :--- | :--- |
-| amount_swapped | int |
+| swapped_tokens | list(int) |
 
 ### swapped\(\)
 
@@ -438,7 +438,7 @@ stateful entrypoint swapped() : map(address, Set.set(int))
 
 | return | type |
 | :--- | :--- |
-| swapped | map(address, Set.set(int)) |
+| swapped_map | map(address, Set.set(int)) |
 
 ## Extension Events
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -13,7 +13,7 @@ Created: 2021-09-11
 
 ## Abstract
 
-A standard implementation of non-fungible tokens for the Aeternity ecosystem. The design goal of the primary interface is to be as compatible with ERC-721 as possible, so that anyone who can work with ERC-721 can work with this interface. However, where Sophia offers a better way, performance and efficiency should prevail over compatibility.
+A standard implementation of non-fungible tokens for the æternity ecosystem. The design goal of the primary interface is to be as compatible with ERC-721 as possible, so that anyone who can work with ERC-721 can work with this interface. However, where Sophia offers a better way, performance and efficiency should prevail over compatibility.
 
 There is no support for unsafe transactions. Therefore all transactions are ought to be safe.
 
@@ -21,11 +21,11 @@ For minting it is expected that different options will evolve over time. The way
 
 ## Motivation
 
-The following standard describes standard interfaces for non-fungible tokens. The proposal contains a primary interface and secondary interfaces for optional functionality that not everyone might need. 
+The following standard describes standard interfaces for non-fungible tokens. The proposal contains a primary interface and secondary interfaces (extensions) for optional functionality that not everyone might need.
 
-# Basic NFT
+# AEX141 NFT
 
-## Interface
+## IAEX141
 
 ```sophia
 contract interface NFT =
@@ -316,26 +316,27 @@ ApprovalForAll(address, address, string)
 
 # Receiver contract interface
 
-The standard only allows safe transfers of tokens. On transfer a check MUST be performed which checks if the recipient is a contract and if so the transfer MAY ONLY happen if `on_nft_received` returns true.
+The standard only allows safe transfers of tokens. On transfer a check MUST be performed which checks if the recipient is a contract and if so the transfer MAY ONLY happen if `on_aex141_received` returns true.
 
-## NFTReceiver
+## AEX141Receiver
 
 ```sophia
-contract interface NFTReceiver = 
-    entrypoint on_nft_received : (int, option(string)) => bool
+contract interface IAEX141Receiver = 
+    entrypoint on_aex141_received : (option(address), int, option(string)) => bool
 ```
 
-### on_nft_received\(\)
+### on_aex141_received\(\)
 
-Deals with receiving NFTs on behalf of a contract. Contracts MUST implement this interface to be able to receive NFTs. Mint and transfer transactions will invoke the `on_nft_received` function.
+Deals with receiving NFTs on behalf of a contract. Contracts MUST implement this interface to be able to receive NFTs. Mint and transfer transactions will invoke the `on_aex141_received` function.
 
 Returns `true` or `false` to signal whether processing the received NFT was successful or not.
 
 ```sophia
-entrypoint on_nft_received(token_id: int, data: option(string)) : bool
+entrypoint on_aex141_received(from: option(address), token_id: int, data: option(string)) : bool
 ```
 | parameter | type |
 | :--- | :--- |
+| from | option(address) |
 | token_id | int |
 | data | option(string) |
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -426,10 +426,10 @@ contract interface IAEX141MintableLimit =
 
     datatype event
         = TokenLimit(int)
-        | TokenLimitChange(int, int)
+        | TokenLimitDecrease(int, int)
 
     entrypoint token_limit : () => int
-    stateful entrypoint change_token_limit : (int) => unit
+    stateful entrypoint decrease_token_limit : (int) => unit
 ```
 
 ### token_limit\(\)
@@ -444,18 +444,18 @@ entrypoint token_limit() : ínt
 | :--- | :--- |
 | token_limit | int |
 
-### change_token_limit\(\)
+### decrease_token_limit\(\)
 
-Changes the NFT limit/cap defined in the collection. The limit/cap MAY ONLY be decreased.
+Decreases the NFT limit/cap defined in the collection. An increase of the limit is forbidden.
 
-Emits the `TokenLimitChange` event.
+Emits the `TokenLimitDecrease` event.
 
 Throws if:
 - `new_limit` equals the current `token_limit`
 - `new_limit` is lower than the current `total_supply`
 
 ```sophia
-stateful entrypoint change_token_limit(new_limit: int) : unit
+stateful entrypoint decrease_token_limit(new_limit: int) : unit
 ```
 
 | parameter | type |
@@ -521,14 +521,14 @@ TokenLimit(int)
 | :--- | :--- |
 | limit | int |
 
-**TokenLimitChange**
+**TokenLimitDecrease**
 
-This event MUST be triggered if the contract implements the `mintable_limit` extension and the `change_token_limit` entrypoint is called.
+This event MUST be triggered if the contract implements the `mintable_limit` extension and the `decrease_token_limit` entrypoint is called.
 
 The event arguments should be as follows: `(old_limit, new_limit)`
 
 ```sophia
-TokenLimitChange(int, int)
+TokenLimitDecrease(int, int)
 ```
 
 | parameter | type |

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -344,8 +344,8 @@ entrypoint on_nft_received(data: option(string)) : bool
 
 This section covers the extendability of the basic token - e.g. mintable, burnable.
 
-When a token contract implements an extension its name should be included in the `aex9_extensions` array, in order for third party software or contracts to know the interface.
-Any extensions should be implementable without permission. Developers of extensions MUST choose a name for `aex9_extensions` that is not yet used. Developers CAN make a pull request to the reference implementation for general purpose extensions and maintainers choose to eventually include them.
+When a token contract implements an extension its name should be included in the `aex141_extensions` array, in order for third party software or contracts to know the interface.
+Any extensions should be implementable without permission. Developers of extensions MUST choose a name for `aex141_extensions` that is not yet used. Developers CAN make a pull request to the reference implementation for general purpose extensions and maintainers choose to eventually include them.
 
 ## Extension Mintable ("mintable")
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -3,7 +3,7 @@
 ```
 AEX: 141
 Title: Non-Fungible Token Standard
-Author: Arjan van Eersel <arjan@toqns.com> (@zkvonsnarkenstein), Marco Walz (@marc0olo), Philipp (@thepiwo)
+Author: Arjan van Eersel <arjan@toqns.com> (@zkvonsnarkenstein), Marco Walz (@marc0olo), Philipp (@thepiwo), Rogerio (@jyeshe)
 License: ISC
 Discussions-To: https://forum.aeternity.com/t/aeternity-nft-token-standard/9781
 Status: Review
@@ -27,7 +27,7 @@ The following standard describes standard interfaces for non-fungible tokens. Th
 
 ```sophia
 contract interface NFT =
-    datatype metadata_type = URL | IPFS | OBJECT_ID | MAP
+    datatype metadata_type = URL | OBJECT_ID | MAP
     datatype metadata = MetadataIdentifier(string) | MetadataMap(map(string, string))
 
     record meta_info = 
@@ -52,7 +52,7 @@ contract interface NFT =
 
     entrypoint owner : (int) => option(address)
    
-    stateful entrypoint transfer : (address, address, int, option(string)) => unit
+    stateful entrypoint transfer : (address, int, option(string)) => unit
 
     stateful entrypoint approve : (address, int, bool) => unit
 
@@ -142,12 +142,11 @@ entrypoint owner(token_id: int) : option(address)
 | owner | option(address) |
 
 ### transfer\(\)
-Transfers NFT with ID `token_id` from the `from` address to the `to` address. Will invoke `NFTReceiver` if `to` address belongs to a contract. If provided, `data` will be submitted with the invocation of `NFTReceiver`. Emits the `Transfer` event.
+Transfers NFT with ID `token_id` from the current owner to the `to` address. Will invoke `NFTReceiver` if `to` address belongs to a contract. If provided, `data` will be submitted with the invocation of `NFTReceiver`. Emits the `Transfer` event.
 
-Should throw if:
-- `Call.caller` is not the current owner, an authorized operator or the approved address for this token;
-- `from` isn't the current owner;
-- `token` isn't a valid token;
+Throws if:
+- `Call.caller` is NOT the current owner or NOT approved to transfer on behalf of the owner;
+- `token` is NOT a valid token;
 - the invocation of `NFTReceiver` fails.
 
 ```sophia
@@ -156,7 +155,6 @@ stateful entrypoint transfer(from: address, to: address, token_id: int, data: op
 
 | parameter | type |
 | :--- | :--- |
-| from | address |
 | to | address |
 | token | int |
 | data | option(string) |
@@ -300,7 +298,7 @@ Approval(address, address, int, string)
 | token_id | int |
 | enabled | string |
 
-## *ApprovalForAll*
+### *ApprovalForAll*
 
 This event MUST be triggered and emitted upon a change of operator status, including revocation of approval.
 
@@ -317,6 +315,40 @@ ApprovalForAll(address, address, string)
 | owner | address |
 | operator | address |
 | approved | string |
+
+# Receiver contract interface
+
+The standard only allows safe transfers of tokens. On transfer a check MUST be performed which checks if the recipient is a contract and if so the transfer MAY ONLY happen if `on_nft_received` returns true.
+
+## NFTReceiver
+
+```sophia
+contract interface NFTReceiver = 
+    entrypoint on_nft_received : (address, address, int, option(string)) => bool
+```
+
+### on_nft_received\(\)
+
+Deals with receiving NFTs on behalf of a contract. Contracts MUST implement this interface to be able to receive NFTs. Mint and transfer transactions will invoke the `on_nft_received` function.
+
+Returns `true` or `false` to signal whether processing the received NFT was successful or not.
+
+```sophia
+entrypoint on_nft_received(from: address, to: address, token_id: int, data: option(string)) : bool
+```
+| parameter | type |
+| :--- | :--- |
+| from | address |
+| to | address |
+| token_id | int |
+| data | option(string) |
+
+# Extensions
+
+This section covers the extendability of the basic token - e.g. mintable, burnable.
+
+When a token contract implements an extension its name should be included in the `aex9_extensions` array, in order for third party software or contracts to know the interface.
+Any extensions should be implementable without permission. Developers of extensions MUST choose a name for `aex9_extensions` that is not yet used. Developers CAN make a pull request to the reference implementation for general purpose extensions and maintainers choose to eventually include them.
 
 ## Extension Mintable ("mintable")
 
@@ -349,6 +381,8 @@ stateful entrypoint mint(owner: address, metadata: option(metadata), data: optio
 Burns the NFT with the provided `token_id`.
 
 Emits the `Burn` event.
+
+Throws if `Call.caller` is NOT the current owner or NOT approved to transfer on behalf of the owner.
 
 ```sophia
 stateful entrypoint burn(token_id: int) : unit
@@ -401,9 +435,9 @@ stateful entrypoint swapped() : map(address, int)
 
 ## Events
 
-**Burn** - MUST trigger when tokens are burned using the `burn` function.
+**Burn** - MUST trigger when NFTs are burned using the `burn` function.
 
-The burn event arguments should be as follows: `(from, token_id)`
+The burn event arguments should be as follows: `(owner, token_id)`
 
 ```sophia
 Burn(address, int)
@@ -411,12 +445,12 @@ Burn(address, int)
 
 | parameter | type |
 | :--- | :--- |
-| from | address |
+| owner | address |
 | token_id | int |
 
-**Swap** - MUST trigger when tokens are swapped using the `swap` function.
+**Swap** - MUST trigger when NFTs are swapped using the `swap` function.
 
-The swap event arguments should be as follows: `(from,  token_id)`
+The swap event arguments should be as follows: `(owner,  token_id)`
 
 ```sophia
 Swap(address, int)
@@ -424,30 +458,5 @@ Swap(address, int)
 
 | parameter | type |
 | :--- | :--- |
-| from | address |
+| owner | address |
 | token_id | int |
-
-# Receiver contract interface
-
-## NFTReceiver
-
-```sophia
-contract interface NFTReceiver = 
-    entrypoint on_nft_received : (address, address, int, option(string)) => bool
-```
-
-### on_nft_received\(\)
-
-Deals with receiving NFTs on behalf of a contract. Contracts MUST implement this interface to be able to receive NFTs. Mint and transfer transactions will invoke the `on_nft_received` function.
-
-Returns `true` or `false` to signal whether processing the received NFT was successful or not.
-
-```sophia
-entrypoint on_nft_received(from: address, to: address, token_id: int, data: option(string)) : bool
-```
-| parameter | type |
-| :--- | :--- |
-| from | address |
-| to | address |
-| token_id | int |
-| data | option(string) |

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -422,7 +422,9 @@ Mint(address, int)
 | to | address |
 | token_id | int |
 
-**Burn** - MUST trigger whenever and NFT is burned.
+**Burn**
+
+This event MUST be triggered whenever an NFT is burned.
 
 The burn event arguments should be as follows: `(owner, token_id)`
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -306,7 +306,7 @@ Approval(address, address, int, string)
 
 ### *ApprovalForAll*
 
-This event MUST be triggered and emitted upon a change of operator status, including revocation of approval.
+This event MUST be triggered and emitted upon a change of operator status, including revocation of approval for all NFTs in the contract.
 
 The event arguments should be as follows: `(owner, operator, approved)`
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -108,7 +108,7 @@ entrypoint metadata(token_id: int) : option(metadata)
 | data | option(metadata) |
 
 The `metadata` type to use depends on the `metadata_type` defined in the contract:
-- for `URL`, `IPFS` and `OBJECT_ID` use `MetadataIdentifier`
+- for `URL`, and `OBJECT_ID` use `MetadataIdentifier`
 - for `MAP` use `MetadataMap`
 
 ### total_supply\(\)


### PR DESCRIPTION
- improves the document format (headings etc.) in general
- introduces explicit `Mint` event for `mintable` extension
- introduces explicit `Burn` event for `burnable` extension
- introduces `total_supply` entrypoint in default interface
- renames `on_nft_received` to `on_aex141_received`
   - changes type `address` to `option(address)` for `from` (on minting `from` does not exist)
   - removes `to` param (most likely not needed) 
- removes the `swappable` extension
    - can be implemented individually, no need to be in a standard
- removes `from` param for `transfer`
- removes the `metadata_type` `IPFS` which doesn't really make sense as we could use `URL` for it (`ipfs://<hash>`)
- introduces `mintable_limit` extension
- introduces `transfer_to_contract` entrypoint