### PR TITLE
extensions: `mintable_templates` & `mutable_attributes`

### DIFF
--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -496,45 +496,96 @@ stateful entrypoint burn(token_id: int) : unit
 
 The `mintable_templates` extension SHOULD be used if multiple NFTs within a contract should share the same metadata. The extension provides the possbility to create templates. Optionally an edition limit for each template can be defined on template creation. If no edition limit is provided, it's considered to be unlimited. The edition limit can be decreased at any point of time as long as the new value does not exceed the current edition supply. Also, templates can be deleted if no NFT has been created using the template.
 
+Note:
+- On contract level the `MAP` MUST be used as `metadata_type`
+   - the map stores the `template_id` and `edition_serial` of each NFT
+   - if `mutable_attributes` extension is used, it also stores the mutable attributes
+- The `template_metadata_type` can either be T_URL (`string`, e.g. `ipfs://` pointing to a JSON stored on IPFS) or T_MAP (`map(string, string)`)
+   - it is defined during contract creation
+   - it is applied to ALL templates created with the contract
+
 ```sophia
 contract interface IAEX141MintableTemplates =
 
-    record template =
-        { immutable_metadata_url: string
-        , edition_limit: option(int)
-        , edition_supply: int }
+    datatype template_metadata_type = T_URL | T_MAP
 
     datatype event 
-        = TemplateCreation(int, string, int)
+        = TemplateCreation(int)
         | TemplateDeletion(int)
         | TemplateMint(address, int, int, string)
         | EditionLimit(int, int)
         | EditionLimitDecrease(int, int, int)
 
+    record template =
+        { immutable_metadata: metadata
+        , edition_limit: option(int)
+        , edition_supply: int }
+
+    entrypoint template_metadata_type : () => template_metadata_type
     entrypoint template : (int) => option(template)
     entrypoint template_supply : () => int
 
-    stateful entrypoint create_template : (string, option(int)) => int
+    stateful entrypoint create_template : (metadata, option(int)) => int
     stateful entrypoint delete_template : (int) => unit
     stateful entrypoint template_mint : (address, int, option(string)) => int
     stateful entrypoint decrease_edition_limit : (int, int) => unit
 ```
 
+### template_metadata_type\(\)
+
+Returns the metadata type which is used for templates.
+
+```sophia
+entrypoint template_metadata_type() : template_metadata_type
+```
+
+| return | type |
+| :--- | :--- |
+| template_metadata_type | template_metadata_type |
+
+### template\(\)
+
+Returns the template for the provided `template_id` in case it exists, otherwise `None`.
+
+```sophia
+entrypoint template(template_id: int) : option(template)
+```
+
+| return | type |
+| :--- | :--- |
+| template | option(template) |
+
+### template_supply\(\)
+
+Returns the total amount of templates that currently exist.
+
+```sophia
+entrypoint template_supply() : ínt
+```
+
+| return | type |
+| :--- | :--- |
+| template_supply | int |
+
 ### create_template\(\)
 
-Creates a new template for specific metadata stored in an immutable data storage (e.g. IPFS). The edition limit defines how many NFTs can be minted based on a specific template. If no edition limit is provided, an unlimited amount of NFTs can be created using the template. The edition limit can be changed at any time and only be decreased.
+Creates a new template for specific immutable metadata. The `immutable_metadata` needs to be `MetadataIdentifier` in case `template_metadata_type` is `T_URL` and `MetadataMap` for `T_MAP`. The edition limit defines how many NFTs can be minted based on a specific template. If no edition limit is provided, an unlimited amount of NFTs can be created using the template. The edition limit can be decreased at any time.
 
 Emits the `TemplateCreation` event.
 
-Note: It's recommended to perform a check if `immutable_metadata_url` is considered valid according to individual requirements.
+Note: It's recommended to perform a check if `immutable_metadata` is considered valid according to individual requirements.
+
+Throws in case the wrong variant for `metadata` is provided:
+- variant MUST be `MetadataIdentifier` if `template_metadata_type` is `T_URL`
+- variant MUST be `MetadataMap` if `template_metadata_type` is `T_MAP`
 
 ```sophia
-stateful entrypoint create_template(immutable_metadata_url: string, edition_limit: option(int)) : int
+stateful entrypoint create_template(immutable_metadata: metadata, edition_limit: option(int)) : int
 ```
 
 | parameter | type |
 | :--- | :--- |
-| immutable_metadata_url | string |
+| immutable_metadata | metadata |
 | edition_limit | option(int) |
 
 | return | type |
@@ -547,7 +598,10 @@ Deletes the template with the provided id.
 
 Emits the `TemplateDeletion` event.
 
-Throws if an NFT based on this template has already been created.
+Throws if:
+
+- the provided `template_id` does not exist
+- an NFT based on this template has already been created
 
 ```sophia
 stateful entrypoint delete_template(template_id: int) : unit
@@ -585,7 +639,7 @@ stateful entrypoint template_mint(to: address, template_id: int, data: option(st
 
 ### decrease_edition_limit\(\)
 
-Decreases the edition limit of a specific template. An increase of the edition limit of a template is forbidden..
+Decreases the edition limit of a specific template. An increase of the edition limit of a template is forbidden.
 
 Emits the `EditionLimitDecrease` event.
 
@@ -746,17 +800,15 @@ Burn(address, int)
 
 This event is defined by the `mintable_templates` extension and MUST be triggered whenever a new template is created.
 
-The event arguments should be as follows: `(template_id, immutable_metadata_url, edition_size)`
+The event arguments should be as follows: `(template_id)`
 
 ```sophia
-TemplateCreation(int, string, int)
+TemplateCreation(int)
 ```
 
 | parameter | type |
 | :--- | :--- |
 | template_id | int |
-| immutable_metadata_url | string |
-| edition_size | int |
 
 **TemplateDeletion**
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -613,7 +613,7 @@ stateful entrypoint delete_template(template_id: int) : unit
 
 ### template_mint\(\)
 
-Mints a new NFT for the provided template id.
+Mints a new NFT for the provided template id. If `to` is a contract, `IAEX141Receiver.on_aex141_received` will be called with `data` if provided.
 
 Emits the `TemplateMint` event.
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -459,7 +459,7 @@ Throws if:
 
 - the provided `template_id` does not exist
 - the mint would exceed the defined `edition_size` of the template
-- the call to `IAEX141Receiver.on_aex141_received()` implementation failed (safe transfer)
+- the call to `IAEX141Receiver.on_aex141_received` implementation failed (safe transfer)
 
 ```sophia
 stateful entrypoint template_mint(to: address, template_id: int, data: option(string)) : int

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -383,6 +383,8 @@ Any extensions should be implementable without permission. Developers of extensi
 
 The `mintable` extension SHOULD be used for generic NFT minting without specific requirements in regards to minting.
 
+Note: If you aim to reuse the same metadata across many NFTs you might prefer the `mintable_templates` extension.
+
 ```sophia
 contract interface IAEX141Mintable =
 
@@ -516,7 +518,6 @@ contract interface IAEX141MintableTemplates =
     stateful entrypoint delete_template : (int) => unit
     stateful entrypoint template_mint : (address, int, option(string)) => int
     stateful entrypoint change_edition_limit : (int, int) => unit
-    
 ```
 
 ### create_template\(\)
@@ -603,6 +604,53 @@ stateful entrypoint change_edition_limit(template_id: int, new_limit: int) : uni
 | :--- | :--- |
 | template_id | int |
 | new_limit  | int |
+
+## Extension Mintable Templates Limit ("mintable_templates_limit")
+
+The `mintable_templates_limit` extension SHOULD be used to introduce a limit/cap for the amount of templates that may be in existence. It MAY ONLY be used in combination with the `mintable_templates` extension.
+
+```sophia
+contract interface IAEX141MintableTemplatesLimit =
+
+    datatype event 
+        = TemplateLimit(int)
+        | TemplateLimitChange(int, int)
+
+    entrypoint template_limit : () => int
+
+    stateful entrypoint change_template_limit : (int) => unit
+```
+
+### template_limit\(\)
+
+Returns the limit / max amount of templates that can be created.
+
+```sophia
+entrypoint template_limit() : ínt
+```
+
+| return | type |
+| :--- | :--- |
+| template_limit | int |
+
+### change_template_limit\(\)
+
+Changes the template limit/cap defined in the contract. The limit/cap MAY ONLY be decreased.
+
+Emits the `TemplateLimitChange` event.
+
+Throws if:
+- `new_limit` equals to or is lower than 0
+- `new_limit` equals the current `token_limit`
+- `new_limit` is lower than the current `total_supply`
+
+```sophia
+stateful entrypoint change_template_limit(new_limit: int) : unit
+```
+
+| parameter | type |
+| :--- | :--- |
+| new_limit | int |
 
 ## Extension Mutable Attributes ("mutable_attributes")
 
@@ -767,6 +815,35 @@ EditionLimitChange(int, int, int)
 | parameter | type |
 | :--- | :--- |
 | template_id | int |
+| old_limit | int |
+| new_limit | int |
+
+**TemplateLimit**
+
+This event is defined by the `mintable_templates_limit` extension and MUST be triggered in the `init` entrypoint during contract creation.
+
+The event arguments should be as follows: `(limit)`
+
+```sophia
+TemplateLimit(int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| limit | int |
+
+**TemplateLimitChange**
+
+This event is defined by the `mintable_templates_limit` extension and MUST be triggered whenever the `change_template_limit` entrypoint is called.
+
+The event arguments should be as follows: `(old_limit, new_limit)`
+
+```sophia
+TemplateLimitChange(int, int)
+```
+
+| parameter | type |
+| :--- | :--- |
 | old_limit | int |
 | new_limit | int |
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -492,47 +492,67 @@ stateful entrypoint burn(token_id: int) : unit
 
 ## Extension Mintable Templates ("mintable_templates")
 
-The `mintable_templates` extension SHOULD be used if multiple NFTs within a contract should share the same metadata. The maximum edition size of NFTs for a specific template needs to be defined on template creation.
+The `mintable_templates` extension SHOULD be used if multiple NFTs within a contract should share the same metadata. The extension provides the possbility to create templates. Optionally an edition limit for each template can be defined on template creation. If no edition limit is provided, it's considered to be unlimited. The edition limit can be decreased at any point of time as long as the new value does not exceed the current edition supply. Also, templates can be deleted if no NFT has been created using the template.
 
 ```sophia
 contract interface IAEX141MintableTemplates =
 
     record template =
         { immutable_metadata_url: string
-        , edition_size: int
-        , edition_mint_count: int }
+        , edition_limit: option(int)
+        , edition_supply: int }
 
     datatype event 
         = TemplateCreation(int, string, int)
+        | TemplateDeletion(int)
         | TemplateMint(address, int, int, string)
+        | EditionLimit(int, int)
+        | EditionLimitChange(int, int, int)
 
-    stateful entrypoint create_template : (string, int) => int
+    entrypoint template : (int) => option(template)
+    entrypoint template_supply : () => int
+
+    stateful entrypoint create_template : (string, option(int)) => int
+    stateful entrypoint delete_template : (int) => unit
     stateful entrypoint template_mint : (address, int, option(string)) => int
+    stateful entrypoint change_edition_limit : (int, int) => unit
+    
 ```
 
 ### create_template\(\)
 
-Creates a new template for specific metadata stored in an immutable data storage (e.g. IPFS). The edition size defines how many NFTs can be minted based on a specific template:
-
-- If 10 is passed as value for the edition size, only 10 NFTs can be minted using the created template
-- If 0 is passed as value, an unlimited amount of NFTs can be minted using the created template
+Creates a new template for specific metadata stored in an immutable data storage (e.g. IPFS). The edition limit defines how many NFTs can be minted based on a specific template. If no edition limit is provided, an unlimited amount of NFTs can be created using the template. The edition limit can be changed at any time and only be decreased.
 
 Emits the `TemplateCreation` event.
-
-Throws if the provided edition size is < 0.
 
 Note: It's recommended to perform a check if `immutable_metadata_url` is considered valid according to individual requirements.
 
 ```sophia
-stateful entrypoint create_template(immutable_metadata_url: string, edition_size: int) : int
+stateful entrypoint create_template(immutable_metadata_url: string, edition_limit: option(int)) : int
 ```
 
 | parameter | type |
 | :--- | :--- |
 | immutable_metadata_url | string |
-| edition_size | int |
+| edition_limit | option(int) |
 
 | return | type |
+| :--- | :--- |
+| template_id | int |
+
+### delete_template\(\)
+
+Deletes the template with the provided id.
+
+Emits the `TemplateDeletion` event.
+
+Throws if an NFT based on this template has already been created.
+
+```sophia
+stateful entrypoint delete_template(template_id: int) : unit
+```
+
+| parameter | type |
 | :--- | :--- |
 | template_id | int |
 
@@ -545,7 +565,7 @@ Emits the `TemplateMint` event.
 Throws if:
 
 - the provided `template_id` does not exist
-- the mint would exceed the defined `edition_size` of the template
+- the mint would exceed the current `edition_limit` of the template
 - the call to `IAEX141Receiver.on_aex141_received` implementation failed (safe transfer)
 
 ```sophia
@@ -562,6 +582,28 @@ stateful entrypoint template_mint(to: address, template_id: int, data: option(st
 | :--- | :--- |
 | token_id | int |
 
+### change_edition_limit\(\)
+
+Changes the edition limit of a specific template. The edition limit of a template MAY ONLY be decreased and MUST be greater than 0.
+
+Emits the `EditionLimitChange` event.
+
+Throws if:
+
+- the provided `template_id` does not exist
+- the `new_limit` is equal to or lower than 0
+- the `new_limit` is equal to or higher than the current edition limit
+- the `new_limit` is lower than the current edition supply
+
+```sophia
+stateful entrypoint change_edition_limit(template_id: int, new_limit: int) : unit
+```
+
+| parameter | type |
+| :--- | :--- |
+| template_id | int |
+| new_limit  | int |
+
 ## Extension Mutable Attributes ("mutable_attributes")
 
 The `mutable_attributes` extension SHOULD be used if NFTs in the contract should store attributes which can change over time. This can e.g. be beneficial for game assets where users could level up their characters. The mutable attributes are expected to be provided in a JSON string.
@@ -569,8 +611,7 @@ The `mutable_attributes` extension SHOULD be used if NFTs in the contract should
 ```sophia
 contract interface IAEX141MutableAttributes =
 
-    datatype event
-        = MutableAttributesUpdate(int, string)
+    datatype event = MutableAttributesUpdate(int, string)
 
     stateful entrypoint update_mutable_attributes : (int, string) => unit
 ```
@@ -596,7 +637,7 @@ stateful entrypoint update_mutable_attributes(token_id: int, mutable_attributes:
 
 **Mint**
 
-This event MUST be triggered whenever a new token is minted with the `mintable` extension.
+This event is defined by the `mintable` extension and MUST be triggered whenever a new token is minted.
 
 The event arguments should be as follows: `(to, token_id)`
 
@@ -611,7 +652,7 @@ Mint(address, int)
 
 **TokenLimit**
 
-This event MUST be triggered in the `init` entrypoint during contract creation if the contract implements the `mintable_limit` extension.
+This event is defined by the `mintable_limit` extension and MUST be triggered in the `init` entrypoint during contract creation.
 
 The event arguments should be as follows: `(limit)`
 
@@ -625,7 +666,7 @@ TokenLimit(int)
 
 **TokenLimitChange**
 
-This event MUST be triggered if the contract implements the `mintable_limit` extension and the `change_token_limit` entrypoint is called.
+This event is defined by the `mintable_limit` extension and MUST be triggered whenever the `change_token_limit` entrypoint is called.
 
 The event arguments should be as follows: `(old_limit, new_limit)`
 
@@ -640,7 +681,7 @@ TokenLimitChange(int, int)
 
 **Burn**
 
-This event MUST be triggered whenever an NFT is burned.
+This event is defined by the `burn` extension and MUST be triggered whenever an NFT is burned.
 
 The event arguments should be as follows: `(owner, token_id)`
 
@@ -655,7 +696,7 @@ Burn(address, int)
 
 **TemplateCreation**
 
-This event MUST be triggered whenever a new template is created with the `mintable_templates` extension.
+This event is defined by the `mintable_templates` extension and MUST be triggered whenever a new template is created.
 
 The event arguments should be as follows: `(template_id, immutable_metadata_url, edition_size)`
 
@@ -669,11 +710,23 @@ TemplateCreation(int, string, int)
 | immutable_metadata_url | string |
 | edition_size | int |
 
+**TemplateDeletion**
+
+This event is defined by the `mintable_templates` extension and MUST be triggered whenever a template is deleted.
+
+The event arguments should be as follows: `(template_id)`
+
+| parameter | type |
+| :--- | :--- |
+| template_id | int |
+
 **TemplateMint**
 
-This event MUST be triggered whenever a new NFT is minted with the `mintable_templates` extension.
+This event is defined by the `mintable_templates` extension and MUST be triggered whenever a new NFT is minted.
 
 The event arguments should be as follows: `(to, template_id, token_id, edition_serial)`. Sophia does not allow 4 "indexed" values as of writing the standard. For this reason `edition_serial` defined as type `string`.
+
+The event arguments should be as follows: `(to, template_id, token_id, edition_serial)`
 
 ```sophia
 TemplateMint(address, int, int, string)
@@ -686,9 +739,40 @@ TemplateMint(address, int, int, string)
 | token_id | int |
 | edition_serial | string |
 
+**EditionLimit**
+
+This event is defined by the `mintable_templates` extension and MUST be triggered whenever a new template is created which specifies an edition limit.
+
+The event arguments should be as follows: `(template_id, edition_limit)`
+
+```sophia
+EditionLimit(int, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| template_id | int |
+| edition_limit | int |
+
+**EditionLimitChange**
+
+This event is defined by the `mintable_templates` extension and MUST be triggered whenever the edition limit of a template is changed.
+
+The event arguments should be as follows: `(template_id, old_limit, new_limit)`
+
+```sophia
+EditionLimitChange(int, int, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| template_id | int |
+| old_limit | int |
+| new_limit | int |
+
 **MutableAttributesUpdate**
 
-This event MUST be triggered whenever the mutable attributes of an NFT are updated with the `mutable_attributes` extension.
+This event is defined by the `mutable_attributes` extension and MUST be triggered whenever the mutable attributes of an NFT are updated.
 
 The event arguments should be as follows: `(token_id, mutable_attributes)`
 

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -3,7 +3,7 @@
 ```
 AEX: 141
 Title: Non-Fungible Token Standard
-Author: Arjan van Eersel <arjan@toqns.com> (@zkvonsnarkenstein)
+Author: Arjan van Eersel <arjan@toqns.com> (@zkvonsnarkenstein), Marco Walz (@marc0olo), Philipp (@thepiwo), Rogerio (@jyeshe)
 License: ISC
 Discussions-To: https://forum.aeternity.com/t/aeternity-nft-token-standard/9781
 Status: Review
@@ -13,28 +13,32 @@ Created: 2021-09-11
 
 ## Abstract
 
-A standard implementation of non-fungible tokens for the Aeternity ecosystem. The design goal of the primary interface is to be as compatible with ERC-721 as possible, so that anyone who can work with ERC-721 can work with this interface. However, where Sophia offers a better way, performance and efficiency should prevail over compatibility.
+A standard implementation of non-fungible tokens for the æternity ecosystem. Initially, the design goal of the primary interface was to be as compatible with ERC-721 as possible, so that anyone who can work with ERC-721 can work with this interface. However, specifically when it comes to dealing with metadata a decision was taken to provide contract developers as much flexibility as possible.
 
-There is no support for unsafe transactions. Therefore all transactions are ought to be safe.
+Core differences to the well-known ERC-721 standard:
+- Unsafe transactions are not supported. Therefore, all transactions are ought to be safe
+- Usage of zero-address for minting or burning is avoided. Thus, explicit events for minting and burning have been defined
+- Token transfers do not require the (owner) address to be passed. Only the recipient address needs to be provided to the entrypoint
+- High flexibility when it comes to dealing with metadata is provided
 
 ## Motivation
 
-The following standard describes standard interfaces for non-fungible tokens. The proposal contains a primary interface and secondary interfaces for optional functionality that not everyone might need. 
+The following standard describes standard interfaces for non-fungible tokens. The proposal contains a primary interface and secondary interfaces (extensions) for optional functionality that not everyone might need.
 
-# Basic NFT
+# AEX141 NFT
 
-## Interface
+## IAEX141
 
 ```sophia
-contract interface NFT =
-    datatype metadata_type = URL | IPFS | OBJECT_ID | MAP
+contract interface IAEX141 =
+    datatype metadata_type = URL | OBJECT_ID | MAP
     datatype metadata = MetadataIdentifier(string) | MetadataMap(map(string, string))
 
     record meta_info = 
         { name: string
         , symbol: string 
         , base_url: option(string)
-        , metadata_type : metadata_type}
+        , metadata_type : metadata_type }
 
     datatype event 
         = Transfer(address, address, int)
@@ -47,11 +51,15 @@ contract interface NFT =
 
     entrypoint metadata : (int) => option(metadata)
 
+    entrypoint total_supply : () => int
+
     entrypoint balance : (address) => option(int)
 
     entrypoint owner : (int) => option(address)
    
-    stateful entrypoint transfer : (address, address, int, option(string)) => unit
+    stateful entrypoint transfer : (address, int, option(string)) => unit
+
+    stateful entrypoint transfer_to_contract : (int) => unit
 
     stateful entrypoint approve : (address, int, bool) => unit
 
@@ -78,6 +86,10 @@ entrypoint aex141_extensions() : list(string)
 
 Returns meta information associated with the contract.
 
+Note:
+- The `base_url` is optional and is only intended to be used if the `metadata_type` is `URL`. As known from ERC-721 this can be used to resolve metadata for a specific NFT which can be fetched from an URL based on the token id
+- The `metadata_type` MUST be defined on contract level and MUST NOT be mixed across various NFTs in a contract
+
 ```sophia
 entrypoint meta_info() : meta_info
 ```
@@ -88,9 +100,19 @@ entrypoint meta_info() : meta_info
 
 ### metadata\(\)
 
-Returns metadata associated with an NFT. 
-The function is a part of the basic interface, because metadata can be set in the constructor, 
-as well as by implementing the Mintable extention.
+Returns metadata associated with an NFT.
+
+Note:
+- The `metadata` can be set in the constructor, as well as by implementing extensions like e.g. `mintable`
+- The `metadata` to use depends on the `metadata_type` defined on contract level and provides certain flexibility:
+  - for `URL` and `OBJECT_ID` use `MetadataIdentifier`
+      - `URL` can represent any URL and typically the NFT id is used to resolve the metadata using that URL, e.g.
+          - `ipfs://` serving as `base_url` and pointing to a folder stored on IPFS where immutable metadata is stored (recommended)
+          - `https://` serving as `base_url` and pointing to a traditional website where metadata is stored
+          - ...
+      - `OBJECT_ID` can be used to refer to any kind of item which typically already exists (e.g. the VIN of a car)
+  - for `MAP` use `MetadataMap`
+    - `MAP` provides almost unlimited flexibility and allows any kind of metadata to be represented in a map
 
 ```sophia
 entrypoint metadata(token_id: int) : option(metadata)
@@ -104,13 +126,21 @@ entrypoint metadata(token_id: int) : option(metadata)
 | :--- | :--- |
 | data | option(metadata) |
 
-The `metadata` type to use depends on the `metadata_type` defined in the contract:
-- for `URL`, `IPFS` and `OBJECT_ID` use `MetadataIdentifier`
-- for `MAP` use `MetadataMap`
+### total_supply\(\)
+
+Returns the total amount of NFTs in circulation.
+
+```sophia
+entrypoint total_supply() : ínt
+```
+
+| return | type |
+| :--- | :--- |
+| total_supply | int |
 
 ### balance\(\)
 
-Returns the account balance of another account with address `owner` if the account has a balance. If the owner address is unknown to the contract, `None` will be returned. Using `option` type as a return value allows us to determine if the account has balance of 0, more than 0, or the account has never had balance and is still unknown to the contract.
+Returns the number of NFTs owned by the account with address `owner` in the contract. If the owner address is unknown to the contract, `None` will be returned. Using `option` type as a return value allows us to determine if the account owns 0, more than 0, or the account has never owned a balance and is still unknown to the contract.
 
 ```sophia
 entrypoint balance(owner: address) : option(int)
@@ -141,23 +171,39 @@ entrypoint owner(token_id: int) : option(address)
 | owner | option(address) |
 
 ### transfer\(\)
-Transfers NFT with ID `token_id` from the `from` address to the `to` address. Will invoke `NFTReceiver` if `to` address belongs to a contract. If provided, `data` will be submitted with the invocation of `NFTReceiver`. Emits the `Transfer` event.
+Transfers NFT with ID `token_id` from the current owner to the `to` address. Will invoke `IAEX141Receiver.on_aex141_received` if the `to` address belongs to a contract. If provided, `data` will be submitted with the invocation of `IAEX141Receiver.on_aex141_received`. Emits the `Transfer` event.
 
-Should throw if:
-- `Call.caller` is not the current owner, an authorized operator or the approved address for this token;
-- `from` isn't the current owner;
-- `token` isn't a valid token;
-- the invocation of `NFTReceiver` fails.
+Note: For security reasons reentrancy is not possible. Therefore contracts cannot use this entrypoint to transfer NFTs to itself. Use `transfer_to_contract` instead to cover this scenario.
+
+Throws if:
+- `Call.caller` is NOT the current owner or NOT approved to transfer on behalf of the owner;
+- `token_id` is NOT a valid token;
+- the invocation of `IAEX141Receiver.on_aex141_received` fails.
 
 ```sophia
-stateful entrypoint transfer(from: address, to: address, token_id: int, data: option(string)) : unit
+stateful entrypoint transfer(to: address, token_id: int, data: option(string)) : unit
 ```
 
 | parameter | type |
 | :--- | :--- |
-| from | address |
+| token_id | int |
+| data | option(string) |
+
+### transfer_to_contract\(\)
+Transfers NFT with ID `token_id` from the current owner to the contract calling this entrypoint. As reentrancy is not possible for security reasons, this entrypoint MUST be used if a contract (e.g. NFT marketplace) wants to transfer the NFT to itself on behalf of the owner. Emits the `Transfer` event.
+
+Throws if:
+- `Call.caller` is NOT a contract or NOT approved to transfer on behalf of the owner;
+- `token_id` is NOT a valid token;
+
+```sophia
+stateful entrypoint transfer(to: address, token_id: int, data: option(string)) : unit
+```
+
+| parameter | type |
+| :--- | :--- |
 | to | address |
-| token | int |
+| token_id | int |
 | data | option(string) |
 
 ### approve\(\)
@@ -224,7 +270,7 @@ entrypoint is_approved(token_id: int, approved: address) : bool
 
 Returns `true` if `operator` is approved to commit transactions on behalf of `owner`.
 
-Indicates wether an address is an authorized operator for another address.
+Indicates whether an address is an authorized operator for another address.
 
 ```sophia
 entrypoint is_approved_for_all(owner: address, operator: address) : bool
@@ -250,7 +296,7 @@ datatype event
 
 ### *Transfer*
 
-This event MUST be triggered and emitted when tokens are transferred, including zero value transfers.
+This event MUST be triggered and emitted when tokens are transferred.
 
 The event arguments should be as follows: `(from, to, token_id)`
 
@@ -282,9 +328,9 @@ Approval(address, address, int, string)
 | token_id | int |
 | enabled | string |
 
-## *ApprovalForAll*
+### *ApprovalForAll*
 
-This event MUST be triggered and emitted upon a change of operator status, including revocation of approval.
+This event MUST be triggered and emitted upon a change of operator status, including revocation of approval for all NFTs in the contract.
 
 The event arguments should be as follows: `(owner, operator, approved)`
 
@@ -300,34 +346,141 @@ ApprovalForAll(address, address, string)
 | operator | address |
 | approved | string |
 
+# Receiver contract interface
+
+The standard only allows safe transfers of tokens. On transfer a check MUST be performed which checks if the recipient is a contract and if so the transfer MAY ONLY happen if `on_aex141_received` returns true.
+
+## AEX141Receiver
+
+```sophia
+contract interface IAEX141Receiver = 
+    entrypoint on_aex141_received : (option(address), int, option(string)) => bool
+```
+
+### on_aex141_received\(\)
+
+Deals with receiving NFTs on behalf of a contract. Contracts MUST implement this interface to be able to receive NFTs. Mint and transfer transactions will invoke the `on_aex141_received` function.
+
+Returns `true` or `false` to signal whether processing the received NFT was successful or not.
+
+```sophia
+entrypoint on_aex141_received(from: option(address), token_id: int, data: option(string)) : bool
+```
+| parameter | type |
+| :--- | :--- |
+| from | option(address) |
+| token_id | int |
+| data | option(string) |
+
+# Extensions
+
+This section covers the extendability of the basic token - e.g. mintable, burnable.
+
+When an NFT contract implements an extension its name should be included in the `aex141_extensions` array, in order for third party software or contracts to know the interface.
+Any extensions should be implementable without permission. Developers of extensions MUST choose a name for `aex141_extensions` that is not yet used. Developers CAN make a pull request to the reference implementation for general purpose extensions and maintainers choose to eventually include them.
+
 ## Extension Mintable ("mintable")
+
+The `mintable` extension SHOULD be used for generic NFT minting without specific requirements in regards to minting.
+
+```sophia
+contract interface IAEX141Mintable =
+
+    datatype event = Mint(address, int)
+
+    stateful entrypoint mint : (address, option(metadata), option(string)) => int
+```
 
 ### mint\(\)
 
-Issues a new token to the provided address. If the `owner` is a contract, NFTReceiver will be called with `data` if provided.
-Emits a Transfer event.
-Throws if the call to NFTReceiver implementation failed (safe transfer). 
+Issues a new token to the provided address. If the `owner` is a contract, `IAEX141Receiver.on_aex141_received` will be called with `data` if provided.
+
+Emits the `Mint` event.
+
+Throws if the call to `IAEX141Receiver.on_aex141_received` implementation failed (safe transfer)
 
 ```sophia
 stateful entrypoint mint(owner: address, metadata: option(metadata), data: option(string)) : int
 ```
 
-| parameter | type | 
-| :--- | :--- | 
+| parameter | type |
+| :--- | :--- |
 | owner | address |
 | metadata | option(metadata) |
-| data  | option(string) | 
+| data  | option(string) |
 
 | return | type |
 | :--- | :--- |
 | token_id | int |
 
+## Extension Mintable Limit ("mintable_limit")
+
+The `mintable_limit` extension SHOULD be used if the amount of NFTs to mint should be limited/capped. It MAY ONLY be used in combination with the `mintable` extension.
+
+The initially defined token limit MUST be greater than or equal to 1.
+
+Emits the `TokenLimit` event on contract creation.
+
+```sophia
+contract interface IAEX141MintableLimit =
+
+    datatype event
+        = TokenLimit(int)
+        | TokenLimitDecrease(int, int)
+
+    entrypoint token_limit : () => int
+    stateful entrypoint decrease_token_limit : (int) => unit
+```
+
+### token_limit\(\)
+
+Returns the limit / max amount of NFTs that can be minted.
+
+```sophia
+entrypoint token_limit() : ínt
+```
+
+| return | type |
+| :--- | :--- |
+| token_limit | int |
+
+### decrease_token_limit\(\)
+
+Decreases the NFT limit/cap defined in the collection. An increase of the limit is forbidden.
+
+Emits the `TokenLimitDecrease` event.
+
+Throws if:
+- `new_limit` equals the current `token_limit`
+- `new_limit` is lower than the current `total_supply`
+
+```sophia
+stateful entrypoint decrease_token_limit(new_limit: int) : unit
+```
+
+| parameter | type |
+| :--- | :--- |
+| new_limit | int |
+
 ## Extension Burnable ("burnable")
+
+The `burnable` extension SHOULD be used if NFTs within a contract are intended to be burnable.
+
+```sophia
+contract interface IAEX141Burnable =
+
+    datatype event = Burn(address, int)
+
+    stateful entrypoint burn : (int) => unit
+```
 
 ### burn\(\)
 
 Burns the NFT with the provided `token_id`.
-Emits the `Transfer` event.
+
+Emits the `Burn` event.
+
+Throws if `Call.caller` is NOT the current owner or NOT approved to transfer on behalf of the owner.
 
 ```sophia
 stateful entrypoint burn(token_id: int) : unit
@@ -337,87 +490,63 @@ stateful entrypoint burn(token_id: int) : unit
 | :--- | :--- |
 | token_id | int |
 
-## Extension Swappable ("swappable")
+## Extension Events
 
-### swap\(\)
+**Mint**
 
-Burns the whole balance of `Call.caller` and stores the same amount in the `swapped` map. 
+This event MUST be triggered whenever a new token is minted with the `mintable` extension.
+
+The event arguments should be as follows: `(to, token_id)`
 
 ```sophia
-stateful entrypoint swap() : unit
+Mint(address, int)
 ```
 
 | parameter | type |
 | :--- | :--- |
-
-| return | type |
-| :--- | :--- |
-| () | unit |
-
-### check_swap\(\)
-
-Returns the amount of NFTs that were burned through `swap` for the provided account. 
-
-```sophia
-stateful entrypoint check_swap(account: address) : int
-```
-
-| parameter | type |
-| :--- | :--- |
-| account | address |
-
-| return | type |
-| :--- | :--- |
-| int | int |
-
-### swapped\(\)
-
-Returns all of the swapped NFTs that are stored in contract state. 
-
-```sophia
-stateful entrypoint swapped() : map(address, int)
-```
-
-| return | type |
-| :--- | :--- |
-| swapped | map(address, int) |
-
-## Events
-
-**Swap** - MUST trigger when tokens are swapped using the `swap` function.
-
-The swap event arguments should be as follows: `(account,  value)`
-
-```sophia
-Swap(address, int)
-```
-
-| parameter | type |
-| :--- | :--- |
-| account| address |
-| value | int |
-
-# Receiver contract interface
-
-## NFTReceiver
-
-```sophia
-contract interface NFTReceiver = 
-    entrypoint on_nft_received : (address, address, int, option(string)) => bool
-```
-
-### on_nft_received\(\)
-
-Deals with receiving NFTs on behalf of a contract. Contracts MUST implement this interface to be able to receive NFTs. Mint and transfer transactions will invoke the `on_nft_received` function.
-
-Returns `true` or `false` to signal whether processing the received NFT was successful or not.
-
-```sophia
-entrypoint on_nft_received(from: address, to: address, token_id: int, data: option(string)) : bool
-```
-| parameter | type |
-| :--- | :--- |
-| from | address |
 | to | address |
 | token_id | int |
-| data | option(string) |
+
+**TokenLimit**
+
+This event MUST be triggered in the `init` entrypoint during contract creation if the contract implements the `mintable_limit` extension.
+
+The event arguments should be as follows: `(limit)`
+
+```sophia
+TokenLimit(int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| limit | int |
+
+**TokenLimitDecrease**
+
+This event MUST be triggered if the contract implements the `mintable_limit` extension and the `decrease_token_limit` entrypoint is called.
+
+The event arguments should be as follows: `(old_limit, new_limit)`
+
+```sophia
+TokenLimitDecrease(int, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| old_limit | int |
+| new_limit | int |
+
+**Burn**
+
+This event MUST be triggered whenever an NFT is burned.
+
+The burn event arguments should be as follows: `(owner, token_id)`
+
+```sophia
+Burn(address, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| owner | address |
+| token_id | int |

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -351,6 +351,11 @@ Any extensions should be implementable without permission. Developers of extensi
 
 The `mintable` extension SHOULD be used for generic NFT minting without specific requirements in regards to minting.
 
+```sophia
+contract interface IAEX141Mintable =
+    stateful entrypoint mint : (address, option(metadata), option(string)) => int
+```
+
 ### mint\(\)
 
 Issues a new token to the provided address. If the `owner` is a contract, `IAEX141Receiver.on_aex141_received` will be called with `data` if provided.
@@ -377,6 +382,11 @@ stateful entrypoint mint(owner: address, metadata: option(metadata), data: optio
 
 The `burnable` extension SHOULD be used if NFTs within a contract are intended to be burnable.
 
+```sophia
+contract interface IAEX141Burnable = 
+    stateful entrypoint burn : (int) => unit
+```
+
 ### burn\(\)
 
 Burns the NFT with the provided `token_id`.
@@ -392,6 +402,108 @@ stateful entrypoint burn(token_id: int) : unit
 | parameter | type |
 | :--- | :--- |
 | token_id | int |
+
+## Extension Mintable Templates ("mintable_templates")
+
+The `mintable_templates` extension SHOULD be used if multiple NFTs within a contract should share the same metadata. The maximum edition size of NFTs for a specific template needs to be defined on template creation.
+
+```sophia
+contract interface IAEX141MintableTemplates =
+
+    record template =
+        { immutable_metadata_url: string
+        , edition_size: int
+        , edition_mint_count: int }
+
+    datatype event 
+        = TemplateCreation(int, string, int)
+        | TemplateMint(address, int, int, string)
+
+    stateful entrypoint create_template : (string, int) => int
+    stateful entrypoint template_mint : (address, int, option(string)) => int
+```
+
+### create_template\(\)
+
+Creates a new template for specific metadata stored in an immutable data storage (e.g. IPFS). The edition size defines how many NFTs can be minted based on a specific template:
+
+- If 10 is passed as value for the edition size, only 10 NFTs can be minted using the created template
+- If 0 is passed as value, an unlimited amount of NFTs can be minted using the created template
+
+Emits the `TemplateCreation` event.
+
+Throws if the provided edition size is < 0.
+
+Note: It's recommended to perform a check if `immutable_metadata_url` is considered valid according to individual requirements.
+
+```sophia
+stateful entrypoint create_template(immutable_metadata_url: string, edition_size: int) : int
+```
+
+| parameter | type |
+| :--- | :--- |
+| immutable_metadata_url | string |
+| edition_size | int |
+
+| return | type |
+| :--- | :--- |
+| template_id | int |
+
+### template_mint\(\)
+
+Mints a new NFT for the provided template id.
+
+Emits the `TemplateMint` event.
+
+Throws if:
+
+- the provided `template_id` does not exist
+- the mint would exceed the defined `edition_size` of the template
+- the call to `IAEX141Receiver.on_aex141_received()` implementation failed (safe transfer)
+
+```sophia
+stateful entrypoint template_mint(to: address, template_id: int, data: option(string)) : int
+```
+
+| parameter | type |
+| :--- | :--- |
+| to | address |
+| template_id | int |
+| data  | option(string) |
+
+| return | type |
+| :--- | :--- |
+| token_id | int |
+
+## Extension Mutable Attributes ("mutable_attributes")
+
+The `mutable_attributes` extension SHOULD be used if NFTs in the contract should store attributes which can change over time. This can e.g. be beneficial for game assets where users could level up their characters. The mutable attributes are expected to be provided in a JSON string.
+
+```sophia
+contract interface IAEX141MutableAttributes =
+
+    datatype event
+        = MutableAttributesUpdate(int, string)
+
+    stateful entrypoint update_mutable_attributes : (int, string) => unit
+```
+
+### update_mutable_attributes\(\)
+
+Updates the JSON string that contains mutable attributes of the NFT.
+
+Emits the `MutableAttributesUpdate` event.
+
+Throws if the provided `token_id` does not exist.
+
+```sophia
+stateful entrypoint update_mutable_attributes(token_id: int, mutable_attributes: string) : unit
+```
+
+| parameter | type |
+| :--- | :--- |
+| token_id | int |
+| mutable_attributes | string |
 
 ## Extension Events
 
@@ -410,9 +522,11 @@ Mint(address, int)
 | to | address |
 | token_id | int |
 
-**Burn** - MUST trigger when NFTs are burned using the `burn` function.
+**Burn**
 
-The burn event arguments should be as follows: `(owner, token_id)`
+This event MUST trigger when NFTs are burned using the `burn` function.
+
+The event arguments should be as follows: `(owner, token_id)`
 
 ```sophia
 Burn(address, int)
@@ -422,3 +536,51 @@ Burn(address, int)
 | :--- | :--- |
 | owner | address |
 | token_id | int |
+
+**TemplateCreation**
+
+This event MUST be triggered whenever a new template is created with the `mintable_templates` extension.
+
+The event arguments should be as follows: `(template_id, immutable_metadata_url, edition_size)`
+
+```sophia
+TemplateCreation(int, string, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| template_id | int |
+| immutable_metadata_url | string |
+| edition_size | int |
+
+**TemplateMint**
+
+This event MUST be triggered whenever a new NFT is minted with the `mintable_templates` extension.
+
+The event arguments should be as follows: `(to, template_id, token_id, edition_serial)`. Sophia does not allow 4 "indexed" values as of writing the standard. For this reason `edition_serial` defined as type `string`.
+
+```sophia
+TemplateMint(address, int, int, string)
+```
+
+| parameter | type |
+| :--- | :--- |
+| to | int |
+| template_id | int |
+| token_id | int |
+| edition_serial | string |
+
+**MutableAttributesUpdate**
+
+This event MUST be triggered whenever the mutable attributes of an NFT are updated with the `mutable_attributes` extension.
+
+The event arguments should be as follows: `(token_id, mutable_attributes)`
+
+```sophia
+MutableAttributesUpdate(token_id, string)
+```
+
+| parameter | type |
+| :--- | :--- |
+| token_id | int |
+| mutable_attributes | string |

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -509,7 +509,7 @@ contract interface IAEX141MintableTemplates =
         | TemplateDeletion(int)
         | TemplateMint(address, int, int, string)
         | EditionLimit(int, int)
-        | EditionLimitChange(int, int, int)
+        | EditionLimitDecrease(int, int, int)
 
     entrypoint template : (int) => option(template)
     entrypoint template_supply : () => int
@@ -517,7 +517,7 @@ contract interface IAEX141MintableTemplates =
     stateful entrypoint create_template : (string, option(int)) => int
     stateful entrypoint delete_template : (int) => unit
     stateful entrypoint template_mint : (address, int, option(string)) => int
-    stateful entrypoint change_edition_limit : (int, int) => unit
+    stateful entrypoint decrease_edition_limit : (int, int) => unit
 ```
 
 ### create_template\(\)
@@ -583,11 +583,11 @@ stateful entrypoint template_mint(to: address, template_id: int, data: option(st
 | :--- | :--- |
 | token_id | int |
 
-### change_edition_limit\(\)
+### decrease_edition_limit\(\)
 
-Changes the edition limit of a specific template. The edition limit of a template MAY ONLY be decreased and MUST be greater than 0.
+Decreases the edition limit of a specific template. An increase of the edition limit of a template is forbidden..
 
-Emits the `EditionLimitChange` event.
+Emits the `EditionLimitDecrease` event.
 
 Throws if:
 
@@ -597,7 +597,7 @@ Throws if:
 - the `new_limit` is lower than the current edition supply
 
 ```sophia
-stateful entrypoint change_edition_limit(template_id: int, new_limit: int) : unit
+stateful entrypoint decrease_edition_limit(template_id: int, new_limit: int) : unit
 ```
 
 | parameter | type |
@@ -614,11 +614,11 @@ contract interface IAEX141MintableTemplatesLimit =
 
     datatype event 
         = TemplateLimit(int)
-        | TemplateLimitChange(int, int)
+        | TemplateLimitDecrease(int, int)
 
     entrypoint template_limit : () => int
 
-    stateful entrypoint change_template_limit : (int) => unit
+    stateful entrypoint decrease_template_limit : (int) => unit
 ```
 
 ### template_limit\(\)
@@ -633,11 +633,11 @@ entrypoint template_limit() : ínt
 | :--- | :--- |
 | template_limit | int |
 
-### change_template_limit\(\)
+### decrease_template_limit\(\)
 
-Changes the template limit/cap defined in the contract. The limit/cap MAY ONLY be decreased.
+Decreases the template limit/cap defined in the contract. An increase of the limit is forbidden.
 
-Emits the `TemplateLimitChange` event.
+Emits the `TemplateLimitDecrease` event.
 
 Throws if:
 - `new_limit` equals to or is lower than 0
@@ -645,7 +645,7 @@ Throws if:
 - `new_limit` is lower than the current `total_supply`
 
 ```sophia
-stateful entrypoint change_template_limit(new_limit: int) : unit
+stateful entrypoint decrease_template_limit(new_limit: int) : unit
 ```
 
 | parameter | type |
@@ -802,14 +802,14 @@ EditionLimit(int, int)
 | template_id | int |
 | edition_limit | int |
 
-**EditionLimitChange**
+**EditionLimitDecrease**
 
-This event is defined by the `mintable_templates` extension and MUST be triggered whenever the edition limit of a template is changed.
+This event is defined by the `mintable_templates` extension and MUST be triggered whenever the `decrease_edition_limit` entrypoint is called.
 
 The event arguments should be as follows: `(template_id, old_limit, new_limit)`
 
 ```sophia
-EditionLimitChange(int, int, int)
+EditionLimitDecrease(int, int, int)
 ```
 
 | parameter | type |
@@ -832,14 +832,14 @@ TemplateLimit(int)
 | :--- | :--- |
 | limit | int |
 
-**TemplateLimitChange**
+**TemplateLimitDecrease**
 
-This event is defined by the `mintable_templates_limit` extension and MUST be triggered whenever the `change_template_limit` entrypoint is called.
+This event is defined by the `mintable_templates_limit` extension and MUST be triggered whenever the `decrease_template_limit` entrypoint is called.
 
 The event arguments should be as follows: `(old_limit, new_limit)`
 
 ```sophia
-TemplateLimitChange(int, int)
+TemplateLimitDecrease(int, int)
 ```
 
 | parameter | type |

--- a/AEXS/aex-141.md
+++ b/AEXS/aex-141.md
@@ -861,3 +861,21 @@ MutableAttributesUpdate(token_id, string)
 | :--- | :--- |
 | token_id | int |
 | mutable_attributes | string |
+
+## Implementation
+
+There are currently following reference implementations available which follows defined standard:
+
+- [aex141-nft-collection-example](https://github.com/aeternity/aex141-nft-collection-example)
+   - [CollectionUniqueNFTs.aes](https://github.com/aeternity/aex141-nft-collection-example/blob/master/contracts/CollectionUniqueNFTs.aes) implements the following extensions:
+        - `mintable`
+        - `mintable_limit`
+        - `burnable`
+   - [CollectionTemplateEditionNFTs.aes](https://github.com/aeternity/aex141-nft-collection-example/blob/master/contracts/CollectionTemplateEditionNFTs.aes) implements the following extensions:
+        - `mintable_templates`
+        - `mintable_templates_limit`
+        - `mutable_attributes`
+        - `burnable`
+
+Additionally there exists following showcase for a simple NFT marketplace using AEX-141:
+- [aex141-nft-simple-marketplace](https://github.com/aeternity/aex141-nft-simple-marketplace)

--- a/AEXS/aex-9.md
+++ b/AEXS/aex-9.md
@@ -22,14 +22,14 @@ The following standard allows for the implementation of a standard API for token
 
 ## Motivation
 
-This standard will allow decentralized applications and wallets to handle tokens across multiple interfaces.
+This standard will allow decentralized applications and wallets to handle fungible tokens in a standardized way.
+A standard interface allows any tokens to be re-used by other applications, e.g. from wallets to decentralized exchanges.
 
-The most important here are `transfer`, `balance` and the `Transfer` event.
+The provided specification is following the ERC20 standard introduced in Ethereum for fungible tokens.
+This standard is proven to be working, it will help with interoperability and easier developer onboarding as the main differences will be Sophia syntax related.
+Another goal with following the ERC20 standard, is to learn from its mistakes and not repeat them.
 
-A standard interface allows any tokens to be re-used by other applications: from wallets to decentralized exchanges.
-
-- The following specification is following the ERC20 standart introduced in Ethereum for fungible tokens.
-- This standart is proven to be working and we think we can leverage of using it. It will also help us with interoperability and easier developers onboarding as the main differences will be Sophia syntax related.
+The newly proposed standard should be easy to use but extendable with more functionality, both first and third party as shown by splitting allowance, minting, burning and swapping into optional extensions.
 
 ## Specification
 
@@ -38,9 +38,7 @@ A standard interface allows any tokens to be re-used by other applications: from
 ### Interface
 
 ```sophia
-@compiler >= 4
-
-contract FungibleTokenInterface =
+contract interface FungibleTokenInterface =
   record meta_info =
     { name : string
     , symbol : string
@@ -160,6 +158,21 @@ Transfer(address, address, int)
 | to_account | address |
 | value | int |
 
+
+**Mint** (optional if token creation happens) - MUST trigger when tokens are minted and thus are newly available in the given token contract, this also applies to tokens created using the `init` method on contract creation.
+
+The mint event arguments should be as follows: `(account,  value)`
+
+```sophia
+Mint(address, int)
+```
+
+| parameter | type |
+| :--- | :--- |
+| account| address |
+| value | int |
+
+
 # Extensions
 
 This section covers the extendability of the basic token - e.g. mintable, burnable and allowances.
@@ -184,7 +197,7 @@ stateful entrypoint mint(account: address, value: int) : unit
 
 ## Events
 
-**Mint** - MUST trigger when tokens are minted using the `mint` function.
+**Mint** - MUST trigger when tokens are minted and thus are newly available in the given token contract, this also applies to tokens created using the `init` method on contract creation.
 
 The mint event arguments should be as follows: `(account,  value)`
 
@@ -213,7 +226,7 @@ stateful entrypoint burn(value: int) : unit
 
 ## Events
 
-**Burn** - MUST trigger when tokens are burned using the `burn` function.
+**Burn** - MUST trigger when tokens are burned and thus are no longer available in the given token contact.
 
 The burn event arguments should be as follows: `(account,  value)`
 
@@ -281,7 +294,7 @@ record allowance_accounts =
 
 ### allowances\(\)
 
-This function returns all of the allowances stored in `state.allowances` record.
+This function returns all allowances stored in `state.allowances` record.
 
 ```sophia
 entrypoint allowances() : allowances
@@ -343,7 +356,7 @@ stateful entrypoint reset_allowance(for_account: address)
 
 ### Events
 
-**Allowance** - MUST trigger on any successful call to `create_allowance(for_account: address, value: int)`.
+**Allowance** - MUST trigger on any successful allowance creation or change.
 
 The approval event arguments should be as follows: `(from_account, for_account, value)`
 
@@ -393,7 +406,7 @@ stateful entrypoint check_swap(account: address) : int
 
 ### swapped\(\)
 
-This function returns all of the swapped tokens that are stored in contract state. 
+This function returns all swapped tokens that are stored in contract state. 
 
 ```sophia
 stateful entrypoint swapped() : map(address, int)
@@ -405,7 +418,7 @@ stateful entrypoint swapped() : map(address, int)
 
 ## Events
 
-**Swap** - MUST trigger when tokens are swapped using the `swap` function.
+**Swap** - MUST trigger when tokens are swapped and thus are no longer available in the given token contact.
 
 The swap event arguments should be as follows: `(account,  value)`
 


### PR DESCRIPTION
based on #148 

introduces:
- `mintable_templates` extension
   - edition limit can be defined on template level and decreased afterwards
- `mintable_templates_limit` extension (to limit the max amount of templates that can exist)
   - template limit can be decreased afterwards
- `mutable_attributes` extension to standardize how mutable attributes are handled